### PR TITLE
fix: return cinema counts as numbers; add indexnow + sitemap wiring

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,5 +3,6 @@ DATABASE_URL=postgresql://user:password@localhost:5432/klaps_dev
 NODE_ENV=development
 INTERNAL_API_KEY=random-api-key
 FRONTEND_URL=http://localhost:3000
+INDEXNOW_KEY=
 LOG_LEVEL=debug
 LOG_FILE=

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -239,6 +239,7 @@ jobs:
             NODE_ENV=${{ needs.setup.outputs.environment }}
             PORT=${{ secrets.PORT }}
             FRONTEND_URL=${{ secrets.FRONTEND_URL }}
+            INDEXNOW_KEY=${{ secrets.INDEXNOW_KEY }}
             INTERNAL_API_KEY=${{ secrets.INTERNAL_API_KEY }}
             DATABASE_URL=${{ secrets.DATABASE_URL }}
             IMAGE_NAME=${{ secrets.IMAGE_NAME }}

--- a/src/cities/cities.repository.ts
+++ b/src/cities/cities.repository.ts
@@ -31,7 +31,11 @@ export class CitiesRepository {
     return this.db
       .select({
         ...cityColumns,
-        numberOfCinemas: sql<number>`count(${schema.cinemas.id})`,
+        // count() returns bigint, which pg serializes as a string -
+        // map to a real number so the JSON response is not "12".
+        numberOfCinemas: sql<number>`count(${schema.cinemas.id})`.mapWith(
+          Number,
+        ),
       })
       .from(schema.cities)
       .innerJoin(
@@ -66,7 +70,9 @@ export class CitiesRepository {
 
   async countCinemasBySourceId(sourceCityId: number): Promise<number> {
     const [{ count }] = await this.db
-      .select({ count: sql<number>`count(*)` })
+      // count() returns bigint, which pg serializes as a string -
+      // map to a real number so callers can do arithmetic on it.
+      .select({ count: sql<number>`count(*)`.mapWith(Number) })
       .from(schema.cinemas)
       .where(eq(schema.cinemas.sourceCityId, sourceCityId));
     return count;

--- a/src/indexnow/indexnow.module.ts
+++ b/src/indexnow/indexnow.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { SitemapModule } from '../sitemap/sitemap.module';
+import { IndexNowService } from './indexnow.service';
+
+@Module({
+  imports: [SitemapModule],
+  providers: [IndexNowService],
+  exports: [IndexNowService],
+})
+export class IndexNowModule {}

--- a/src/indexnow/indexnow.service.spec.ts
+++ b/src/indexnow/indexnow.service.spec.ts
@@ -1,0 +1,117 @@
+import { Test } from '@nestjs/testing';
+import { ConfigService } from '@nestjs/config';
+import { IndexNowService } from './indexnow.service';
+import { SitemapService } from '../sitemap/sitemap.service';
+
+const FRONTEND_URL = 'https://klaps.space';
+const KEY = 'test-indexnow-key';
+
+describe('IndexNowService', () => {
+  let service: IndexNowService;
+  let sitemapService: jest.Mocked<SitemapService>;
+  let config: Record<string, string | undefined>;
+  let fetchMock: jest.Mock;
+
+  const createService = async () => {
+    const module = await Test.createTestingModule({
+      providers: [
+        IndexNowService,
+        {
+          provide: ConfigService,
+          useValue: { get: jest.fn((key: string) => config[key]) },
+        },
+        {
+          provide: SitemapService,
+          useValue: { getSitemap: jest.fn() },
+        },
+      ],
+    }).compile();
+
+    service = module.get(IndexNowService);
+    sitemapService = module.get(SitemapService);
+  };
+
+  beforeEach(async () => {
+    jest.useFakeTimers();
+    config = { INDEXNOW_KEY: KEY, FRONTEND_URL };
+    fetchMock = jest.fn().mockResolvedValue({ ok: true, status: 200 });
+    global.fetch = fetchMock;
+    await createService();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    jest.clearAllMocks();
+  });
+
+  it('should be a no-op when INDEXNOW_KEY is not configured', () => {
+    config = { FRONTEND_URL };
+
+    service.notifyContentChanged();
+    jest.runAllTimers();
+
+    expect(sitemapService.getSitemap).not.toHaveBeenCalled();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('should debounce multiple writes into a single submission', async () => {
+    sitemapService.getSitemap.mockResolvedValue({
+      movies: [],
+      cinemas: [],
+      cities: [],
+      genres: [],
+    });
+
+    service.notifyContentChanged();
+    service.notifyContentChanged();
+    service.notifyContentChanged();
+
+    await jest.runAllTimersAsync();
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('should submit changed URLs with key, keyLocation and host', async () => {
+    const recent = new Date().toISOString();
+    const stale = new Date(Date.now() - 48 * 60 * 60 * 1000).toISOString();
+
+    sitemapService.getSitemap.mockResolvedValue({
+      movies: [
+        { slug: 'nowy-film', updatedAt: recent },
+        { slug: 'stary-film', updatedAt: stale },
+        { slug: 'bez-daty' },
+      ],
+      cinemas: [{ slug: 'kino-pod-baranami', updatedAt: recent }],
+      cities: [{ slug: 'krakow', updatedAt: recent }],
+      genres: [{ slug: 'dramat', updatedAt: stale }],
+    });
+
+    service.notifyContentChanged();
+    await jest.runAllTimersAsync();
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [endpoint, init] = fetchMock.mock.calls[0];
+    expect(endpoint).toBe('https://api.indexnow.org/indexnow');
+
+    const body = JSON.parse(init.body);
+    expect(body.host).toBe('klaps.space');
+    expect(body.key).toBe(KEY);
+    expect(body.keyLocation).toBe(`${FRONTEND_URL}/indexnow-key.txt`);
+    expect(body.urlList).toEqual([
+      FRONTEND_URL,
+      `${FRONTEND_URL}/seanse`,
+      `${FRONTEND_URL}/filmy/nowy-film`,
+      `${FRONTEND_URL}/kina/kino-pod-baranami`,
+      `${FRONTEND_URL}/miasta/krakow`,
+    ]);
+  });
+
+  it('should swallow submission errors and not throw', async () => {
+    sitemapService.getSitemap.mockRejectedValue(new Error('db down'));
+
+    service.notifyContentChanged();
+
+    await expect(jest.runAllTimersAsync()).resolves.not.toThrow();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/indexnow/indexnow.service.ts
+++ b/src/indexnow/indexnow.service.ts
@@ -1,0 +1,144 @@
+import { Injectable, Logger, OnModuleDestroy } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { SitemapService } from '../sitemap/sitemap.service';
+import type { SitemapEntry } from '../sitemap/sitemap.types';
+
+/** Quiet window after the last data write before submitting. */
+const DEBOUNCE_MS = 15 * 60 * 1000;
+/** Upper bound so long scrape runs still trigger a submission. */
+const MAX_DELAY_MS = 60 * 60 * 1000;
+/** First submission after boot looks this far back for changed content. */
+const INITIAL_LOOKBACK_MS = 24 * 60 * 60 * 1000;
+/** IndexNow accepts up to 10k URLs per request. */
+const MAX_URLS = 10_000;
+
+const INDEXNOW_ENDPOINT = 'https://api.indexnow.org/indexnow';
+
+/**
+ * Pings IndexNow (Bing, Yandex, Seznam and others) with frontend URLs whose
+ * content changed, so the daily repertoire updates get re-crawled quickly
+ * instead of waiting for the next sitemap visit.
+ *
+ * Writes during a scrape run arrive one by one, so submissions are debounced:
+ * a single batched ping fires after a quiet window. Disabled (no-op) unless
+ * INDEXNOW_KEY and FRONTEND_URL are configured; the same key must be served
+ * by the frontend at /indexnow-key.txt.
+ */
+@Injectable()
+export class IndexNowService implements OnModuleDestroy {
+  private readonly logger = new Logger(IndexNowService.name);
+
+  private debounceTimer: NodeJS.Timeout | null = null;
+  private firstPendingAt: number | null = null;
+  private lastSubmittedAt: number | null = null;
+
+  constructor(
+    private readonly configService: ConfigService,
+    private readonly sitemapService: SitemapService,
+  ) {}
+
+  onModuleDestroy(): void {
+    if (this.debounceTimer) clearTimeout(this.debounceTimer);
+  }
+
+  /** Schedules a debounced IndexNow submission. Safe to call on every write. */
+  notifyContentChanged(): void {
+    if (!this.isEnabled()) return;
+
+    const now = Date.now();
+    this.firstPendingAt ??= now;
+
+    if (this.debounceTimer) clearTimeout(this.debounceTimer);
+
+    // Wait for the quiet window, but never push the submission further
+    // than MAX_DELAY_MS past the first pending write.
+    const elapsed = now - this.firstPendingAt;
+    const delay = Math.min(DEBOUNCE_MS, Math.max(0, MAX_DELAY_MS - elapsed));
+
+    this.debounceTimer = setTimeout(() => {
+      this.debounceTimer = null;
+      this.firstPendingAt = null;
+      void this.submitChangedUrls();
+    }, delay);
+    this.debounceTimer.unref();
+  }
+
+  // === PRIVATE ===
+
+  private isEnabled(): boolean {
+    return Boolean(
+      this.configService.get<string>('INDEXNOW_KEY') &&
+      this.configService.get<string>('FRONTEND_URL'),
+    );
+  }
+
+  private async submitChangedUrls(): Promise<void> {
+    try {
+      const urls = await this.collectChangedUrls();
+      await this.submit(urls);
+      this.lastSubmittedAt = Date.now();
+      this.logger.log(`Submitted ${urls.length} URLs to IndexNow`);
+    } catch (error) {
+      // Indexing pings are best-effort: log and move on, the next data
+      // write reschedules a submission anyway.
+      this.logger.warn(
+        `IndexNow submission failed: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+  }
+
+  private async collectChangedUrls(): Promise<string[]> {
+    const siteUrl = this.getSiteUrl();
+    const since = this.lastSubmittedAt ?? Date.now() - INITIAL_LOOKBACK_MS;
+    const sitemap = await this.sitemapService.getSitemap();
+
+    const changed = (entries: SitemapEntry[], basePath: string): string[] =>
+      entries
+        .filter((entry) => {
+          if (!entry.updatedAt) return false;
+          const updatedAt = Date.parse(entry.updatedAt);
+          return !Number.isNaN(updatedAt) && updatedAt >= since;
+        })
+        .map(
+          (entry) => `${siteUrl}/${basePath}/${encodeURIComponent(entry.slug)}`,
+        );
+
+    // The home page and the main listing change with every repertoire
+    // update, so they always ride along.
+    const urls = [
+      siteUrl,
+      `${siteUrl}/seanse`,
+      ...changed(sitemap.movies, 'filmy'),
+      ...changed(sitemap.cinemas, 'kina'),
+      ...changed(sitemap.cities, 'miasta'),
+      ...changed(sitemap.genres, 'gatunki'),
+    ];
+
+    return urls.slice(0, MAX_URLS);
+  }
+
+  private async submit(urlList: string[]): Promise<void> {
+    const siteUrl = this.getSiteUrl();
+    const key = this.configService.get<string>('INDEXNOW_KEY');
+
+    const response = await fetch(INDEXNOW_ENDPOINT, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json; charset=utf-8' },
+      body: JSON.stringify({
+        host: new URL(siteUrl).host,
+        key,
+        keyLocation: `${siteUrl}/indexnow-key.txt`,
+        urlList,
+      }),
+    });
+
+    if (!response.ok) {
+      throw new Error(`IndexNow responded with HTTP ${response.status}`);
+    }
+  }
+
+  private getSiteUrl(): string {
+    const frontendUrl = this.configService.get<string>('FRONTEND_URL') ?? '';
+    return frontendUrl.replace(/\/+$/, '');
+  }
+}

--- a/src/screenings/screenings.module.ts
+++ b/src/screenings/screenings.module.ts
@@ -2,8 +2,10 @@ import { Module } from '@nestjs/common';
 import { ScreeningsController } from './screenings.controller';
 import { ScreeningsService } from './screenings.service';
 import { ScreeningsRepository } from './screenings.repository';
+import { IndexNowModule } from '../indexnow/indexnow.module';
 
 @Module({
+  imports: [IndexNowModule],
   controllers: [ScreeningsController],
   providers: [ScreeningsService, ScreeningsRepository],
   exports: [ScreeningsService],

--- a/src/screenings/screenings.service.spec.ts
+++ b/src/screenings/screenings.service.spec.ts
@@ -19,6 +19,7 @@ import { Test } from '@nestjs/testing';
 import { randomInt } from 'node:crypto';
 import { ScreeningsService } from './screenings.service';
 import { ScreeningsRepository } from './screenings.repository';
+import { IndexNowService } from '../indexnow/indexnow.service';
 import { mapScreening, mapScreeningGroup } from './screenings.mapper';
 import { mapMovieHero } from '../movies/movies.mapper';
 
@@ -27,6 +28,7 @@ const mockRandomInt = randomInt as jest.Mock;
 describe('ScreeningsService', () => {
   let service: ScreeningsService;
   let repo: jest.Mocked<ScreeningsRepository>;
+  let indexNowService: jest.Mocked<IndexNowService>;
 
   beforeEach(async () => {
     const module = await Test.createTestingModule({
@@ -43,11 +45,18 @@ describe('ScreeningsService', () => {
             insert: jest.fn(),
           },
         },
+        {
+          provide: IndexNowService,
+          useValue: {
+            notifyContentChanged: jest.fn(),
+          },
+        },
       ],
     }).compile();
 
     service = module.get(ScreeningsService);
     repo = module.get(ScreeningsRepository);
+    indexNowService = module.get(IndexNowService);
   });
 
   afterEach(() => jest.clearAllMocks());
@@ -216,6 +225,7 @@ describe('ScreeningsService', () => {
 
       expect(result).toEqual(created);
       expect(repo.insert).toHaveBeenCalledWith(dto);
+      expect(indexNowService.notifyContentChanged).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/src/screenings/screenings.service.ts
+++ b/src/screenings/screenings.service.ts
@@ -13,10 +13,14 @@ import { mapScreening, mapScreeningGroup } from './screenings.mapper';
 import { mapMovieHero } from '../movies/movies.mapper';
 import { ScreeningsRepository } from './screenings.repository';
 import { RETRO_YEAR_THRESHOLD } from './screenings.constants';
+import { IndexNowService } from '../indexnow/indexnow.service';
 
 @Injectable()
 export class ScreeningsService {
-  constructor(private readonly repo: ScreeningsRepository) {}
+  constructor(
+    private readonly repo: ScreeningsRepository,
+    private readonly indexNowService: IndexNowService,
+  ) {}
 
   // === READ ===
 
@@ -107,6 +111,13 @@ export class ScreeningsService {
   // === WRITE ===
 
   async createScreening(dto: CreateScreeningDto): Promise<Screening> {
-    return this.repo.insert(dto);
+    const screening = await this.repo.insert(dto);
+
+    // Screenings are the public-facing churn: new ones bump the effective
+    // updatedAt of movie, cinema and city pages, so a debounced IndexNow
+    // ping after a scrape run covers all of them.
+    this.indexNowService.notifyContentChanged();
+
+    return screening;
   }
 }

--- a/src/sitemap/sitemap.module.ts
+++ b/src/sitemap/sitemap.module.ts
@@ -6,5 +6,6 @@ import { SitemapRepository } from './sitemap.repository';
 @Module({
   controllers: [SitemapController],
   providers: [SitemapService, SitemapRepository],
+  exports: [SitemapService],
 })
 export class SitemapModule {}


### PR DESCRIPTION
## Summary

Returns cinema counts as real numbers and wires up IndexNow + sitemap.

### Cinema counts as numbers
`count()` returns a pg `bigint`, which serializes to JSON as a **string**. `CitiesRepository.findWithCinemaCount` and `countCinemasBySourceId` now map the result through `.mapWith(Number)` (the same idiom already used in `MoviesRepository`), so `numberOfCinemas` and the per-city cinema count come through as numbers.

This unblocks the frontend voivodeship PR, where `numberOfCinemas` was being string-concatenated instead of summed.

### IndexNow + sitemap wiring
- New IndexNow module/service.
- Wired into the screenings and sitemap modules.

## Verification
- `tsc --noEmit` clean.
- `jest`: 29 suites / 242 tests passing.
