### PR TITLE
chore: merge dev into main

### DIFF
--- a/src/movies/movies.controller.spec.ts
+++ b/src/movies/movies.controller.spec.ts
@@ -42,7 +42,7 @@ const mockMovieDetail: MovieResponse = {
   polishPremiereDate: '2010-07-30',
   genres: [{ id: 1, slug: 'action', name: 'Action', description: null }],
   actors: [{ id: 1, name: 'Leonardo DiCaprio' }],
-  directors: [{ id: 1, name: 'Christopher Nolan' }],
+  directors: [{ id: 1, slug: 'christopher-nolan', name: 'Christopher Nolan' }],
   scriptwriters: [{ id: 1, name: 'Christopher Nolan' }],
   countries: [{ id: 1, name: 'USA' }],
   ratings: {

--- a/src/movies/movies.mapper.ts
+++ b/src/movies/movies.mapper.ts
@@ -30,7 +30,9 @@ type DbMovieWithGenres = {
 
 type DbMovieWithRelations = DbMovieWithGenres & {
   movies_actors: Array<{ actor: { id: number; name: string } }>;
-  movies_directors: Array<{ director: { id: number; name: string } }>;
+  movies_directors: Array<{
+    director: { id: number; slug: string | null; name: string };
+  }>;
   movies_scriptwriters: Array<{ scriptwriter: { id: number; name: string } }>;
   movies_countries: Array<{ country: { id: number; name: string } }>;
 };
@@ -83,8 +85,9 @@ export const mapMovieDetail = (movie: DbMovieWithRelations): MovieResponse => ({
   polishPremiereDate: formatDateField(movie.polishPremiereDate),
   genres: movie.movies_genres.map((mg) => mapGenre(mg.genre)),
   actors: movie.movies_actors.map(({ actor: { id, name } }) => ({ id, name })),
-  directors: movie.movies_directors.map(({ director: { id, name } }) => ({
+  directors: movie.movies_directors.map(({ director: { id, slug, name } }) => ({
     id,
+    slug: slug ?? null,
     name,
   })),
   scriptwriters: movie.movies_scriptwriters.map(

--- a/src/movies/movies.service.spec.ts
+++ b/src/movies/movies.service.spec.ts
@@ -32,7 +32,11 @@ const mockDbMovie = {
   updatedAt: new Date('2025-01-01'),
   movies_genres: [{ genre: { id: 1, slug: 'action', name: 'Action' } }],
   movies_actors: [{ actor: { id: 1, name: 'Leonardo DiCaprio' } }],
-  movies_directors: [{ director: { id: 1, name: 'Christopher Nolan' } }],
+  movies_directors: [
+    {
+      director: { id: 1, slug: 'christopher-nolan', name: 'Christopher Nolan' },
+    },
+  ],
   movies_scriptwriters: [
     { scriptwriter: { id: 1, name: 'Christopher Nolan' } },
   ],
@@ -162,6 +166,11 @@ describe('MoviesService', () => {
       expect(result).not.toBeNull();
       expect(result!.slug).toBe('inception-2010');
       expect(result!.filmwebUrl).toBe('https://filmweb.pl/inception');
+      expect(result!.directors[0]).toEqual({
+        id: 1,
+        slug: 'christopher-nolan',
+        name: 'Christopher Nolan',
+      });
       expect(repo.findBySlug).toHaveBeenCalledWith('inception-2010');
     });
 

--- a/src/movies/movies.types.ts
+++ b/src/movies/movies.types.ts
@@ -53,7 +53,7 @@ export type MovieResponse = {
   polishPremiereDate: string | null;
   genres: GenreResponse[];
   actors: { id: number; name: string }[];
-  directors: { id: number; name: string }[];
+  directors: { id: number; slug: string | null; name: string }[];
   scriptwriters: { id: number; name: string }[];
   countries: { id: number; name: string }[];
   ratings: {


### PR DESCRIPTION
Promote PR #42 to production: MovieResponse.directors carries slug for direct frontend linking. Mapper/type change only — no migration.