### PR TITLE
feat(socials): image hosting endpoint and movie repeat cooldown

### DIFF
--- a/src/database/migrations/0005_socials_images.sql
+++ b/src/database/migrations/0005_socials_images.sql
@@ -1,0 +1,6 @@
+CREATE TABLE "socials_images" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"data" "bytea" NOT NULL,
+	"contentType" varchar(100) NOT NULL,
+	"createdAt" timestamp DEFAULT now() NOT NULL
+);

--- a/src/database/migrations/meta/0005_snapshot.json
+++ b/src/database/migrations/meta/0005_snapshot.json
@@ -1,0 +1,1502 @@
+{
+  "id": "0411154b-6e13-475a-87e8-5383a012fcdb",
+  "prevId": "e30c3752-9029-4ec6-8ca6-2ba08679923f",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.actors": {
+      "name": "actors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "sourceId": {
+          "name": "sourceId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "actors_sourceId_unique": {
+          "name": "actors_sourceId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "sourceId"
+          ]
+        },
+        "actors_url_unique": {
+          "name": "actors_url_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "url"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cinemas": {
+      "name": "cinemas",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "sourceId": {
+          "name": "sourceId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sourceCityId": {
+          "name": "sourceCityId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "street": {
+          "name": "street",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "cinemas_sourceCityId_cities_sourceId_fk": {
+          "name": "cinemas_sourceCityId_cities_sourceId_fk",
+          "tableFrom": "cinemas",
+          "tableTo": "cities",
+          "columnsFrom": [
+            "sourceCityId"
+          ],
+          "columnsTo": [
+            "sourceId"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "cinemas_sourceId_unique": {
+          "name": "cinemas_sourceId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "sourceId"
+          ]
+        },
+        "cinemas_slug_unique": {
+          "name": "cinemas_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cities": {
+      "name": "cities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "sourceId": {
+          "name": "sourceId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "nameDeclinated": {
+          "name": "nameDeclinated",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "areacode": {
+          "name": "areacode",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "population": {
+          "name": "population",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "voivodeship": {
+          "name": "voivodeship",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastScrapedAt": {
+          "name": "lastScrapedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "cities_sourceId_unique": {
+          "name": "cities_sourceId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "sourceId"
+          ]
+        },
+        "cities_slug_unique": {
+          "name": "cities_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.countries": {
+      "name": "countries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "countryCode": {
+          "name": "countryCode",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "countries_countryCode_unique": {
+          "name": "countries_countryCode_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "countryCode"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.directors": {
+      "name": "directors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "sourceId": {
+          "name": "sourceId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'director'"
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "photoUrl": {
+          "name": "photoUrl",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "directors_sourceId_unique": {
+          "name": "directors_sourceId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "sourceId"
+          ]
+        },
+        "directors_slug_unique": {
+          "name": "directors_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.genres": {
+      "name": "genres",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "sourceId": {
+          "name": "sourceId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "genres_sourceId_unique": {
+          "name": "genres_sourceId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "sourceId"
+          ]
+        },
+        "genres_slug_unique": {
+          "name": "genres_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.movies": {
+      "name": "movies",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "sourceId": {
+          "name": "sourceId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "titleOriginal": {
+          "name": "titleOriginal",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "productionYear": {
+          "name": "productionYear",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "worldPremiereDate": {
+          "name": "worldPremiereDate",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "polishPremiereDate": {
+          "name": "polishPremiereDate",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "usersRating": {
+          "name": "usersRating",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "usersRatingVotes": {
+          "name": "usersRatingVotes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "criticsRating": {
+          "name": "criticsRating",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "criticsRatingVotes": {
+          "name": "criticsRatingVotes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "language": {
+          "name": "language",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "posterUrl": {
+          "name": "posterUrl",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "backdropUrl": {
+          "name": "backdropUrl",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "videoUrl": {
+          "name": "videoUrl",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "boxoffice": {
+          "name": "boxoffice",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "budget": {
+          "name": "budget",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "distribution": {
+          "name": "distribution",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "movies_sourceId_unique": {
+          "name": "movies_sourceId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "sourceId"
+          ]
+        },
+        "movies_slug_unique": {
+          "name": "movies_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.movies_actors": {
+      "name": "movies_actors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "movieId": {
+          "name": "movieId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actorId": {
+          "name": "actorId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "movies_actors_movieId_movies_id_fk": {
+          "name": "movies_actors_movieId_movies_id_fk",
+          "tableFrom": "movies_actors",
+          "tableTo": "movies",
+          "columnsFrom": [
+            "movieId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "movies_actors_actorId_actors_id_fk": {
+          "name": "movies_actors_actorId_actors_id_fk",
+          "tableFrom": "movies_actors",
+          "tableTo": "actors",
+          "columnsFrom": [
+            "actorId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "movies_actors_movieId_actorId_unique": {
+          "name": "movies_actors_movieId_actorId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "movieId",
+            "actorId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.movies_countries": {
+      "name": "movies_countries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "movieId": {
+          "name": "movieId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "countryId": {
+          "name": "countryId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "movies_countries_movieId_movies_id_fk": {
+          "name": "movies_countries_movieId_movies_id_fk",
+          "tableFrom": "movies_countries",
+          "tableTo": "movies",
+          "columnsFrom": [
+            "movieId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "movies_countries_countryId_countries_id_fk": {
+          "name": "movies_countries_countryId_countries_id_fk",
+          "tableFrom": "movies_countries",
+          "tableTo": "countries",
+          "columnsFrom": [
+            "countryId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "movies_countries_movieId_countryId_unique": {
+          "name": "movies_countries_movieId_countryId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "movieId",
+            "countryId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.movies_directors": {
+      "name": "movies_directors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "movieId": {
+          "name": "movieId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "directorId": {
+          "name": "directorId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "movies_directors_movieId_movies_id_fk": {
+          "name": "movies_directors_movieId_movies_id_fk",
+          "tableFrom": "movies_directors",
+          "tableTo": "movies",
+          "columnsFrom": [
+            "movieId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "movies_directors_directorId_directors_id_fk": {
+          "name": "movies_directors_directorId_directors_id_fk",
+          "tableFrom": "movies_directors",
+          "tableTo": "directors",
+          "columnsFrom": [
+            "directorId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "movies_directors_movieId_directorId_unique": {
+          "name": "movies_directors_movieId_directorId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "movieId",
+            "directorId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.movies_genres": {
+      "name": "movies_genres",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "movieId": {
+          "name": "movieId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "genreId": {
+          "name": "genreId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "movies_genres_movieId_movies_id_fk": {
+          "name": "movies_genres_movieId_movies_id_fk",
+          "tableFrom": "movies_genres",
+          "tableTo": "movies",
+          "columnsFrom": [
+            "movieId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "movies_genres_genreId_genres_id_fk": {
+          "name": "movies_genres_genreId_genres_id_fk",
+          "tableFrom": "movies_genres",
+          "tableTo": "genres",
+          "columnsFrom": [
+            "genreId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "movies_genres_movieId_genreId_unique": {
+          "name": "movies_genres_movieId_genreId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "movieId",
+            "genreId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.movies_scriptwriters": {
+      "name": "movies_scriptwriters",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "movieId": {
+          "name": "movieId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scriptwriterId": {
+          "name": "scriptwriterId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "movies_scriptwriters_movieId_movies_id_fk": {
+          "name": "movies_scriptwriters_movieId_movies_id_fk",
+          "tableFrom": "movies_scriptwriters",
+          "tableTo": "movies",
+          "columnsFrom": [
+            "movieId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "movies_scriptwriters_scriptwriterId_scriptwriters_id_fk": {
+          "name": "movies_scriptwriters_scriptwriterId_scriptwriters_id_fk",
+          "tableFrom": "movies_scriptwriters",
+          "tableTo": "scriptwriters",
+          "columnsFrom": [
+            "scriptwriterId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "movies_scriptwriters_movieId_scriptwriterId_unique": {
+          "name": "movies_scriptwriters_movieId_scriptwriterId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "movieId",
+            "scriptwriterId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.screenings": {
+      "name": "screenings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "movieId": {
+          "name": "movieId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "showtimeId": {
+          "name": "showtimeId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cinemaId": {
+          "name": "cinemaId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "isDubbing": {
+          "name": "isDubbing",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "isSubtitled": {
+          "name": "isSubtitled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "screenings_movieId_movies_id_fk": {
+          "name": "screenings_movieId_movies_id_fk",
+          "tableFrom": "screenings",
+          "tableTo": "movies",
+          "columnsFrom": [
+            "movieId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "screenings_showtimeId_showtimes_id_fk": {
+          "name": "screenings_showtimeId_showtimes_id_fk",
+          "tableFrom": "screenings",
+          "tableTo": "showtimes",
+          "columnsFrom": [
+            "showtimeId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "screenings_cinemaId_cinemas_sourceId_fk": {
+          "name": "screenings_cinemaId_cinemas_sourceId_fk",
+          "tableFrom": "screenings",
+          "tableTo": "cinemas",
+          "columnsFrom": [
+            "cinemaId"
+          ],
+          "columnsTo": [
+            "sourceId"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "screenings_unique": {
+          "name": "screenings_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "movieId",
+            "cinemaId",
+            "date",
+            "type",
+            "isDubbing",
+            "isSubtitled"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.scriptwriters": {
+      "name": "scriptwriters",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "sourceId": {
+          "name": "sourceId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "scriptwriters_sourceId_unique": {
+          "name": "scriptwriters_sourceId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "sourceId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.showtimes": {
+      "name": "showtimes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cityId": {
+          "name": "cityId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "showtimes_cityId_cities_id_fk": {
+          "name": "showtimes_cityId_cities_id_fk",
+          "tableFrom": "showtimes",
+          "tableTo": "cities",
+          "columnsFrom": [
+            "cityId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "showtimes_url_unique": {
+          "name": "showtimes_url_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "url"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.socials_images": {
+      "name": "socials_images",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "data": {
+          "name": "data",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contentType": {
+          "name": "contentType",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.socials_posts": {
+      "name": "socials_posts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "postDate": {
+          "name": "postDate",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform": {
+          "name": "platform",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'instagram_post'"
+        },
+        "contentType": {
+          "name": "contentType",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'feed_candidate'"
+        },
+        "movieId": {
+          "name": "movieId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "screeningId": {
+          "name": "screeningId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "published": {
+          "name": "published",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "socials_posts_movieId_movies_id_fk": {
+          "name": "socials_posts_movieId_movies_id_fk",
+          "tableFrom": "socials_posts",
+          "tableTo": "movies",
+          "columnsFrom": [
+            "movieId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "socials_posts_screeningId_screenings_id_fk": {
+          "name": "socials_posts_screeningId_screenings_id_fk",
+          "tableFrom": "socials_posts",
+          "tableTo": "screenings",
+          "columnsFrom": [
+            "screeningId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "socials_posts_postDate_platform_content_type_unique": {
+          "name": "socials_posts_postDate_platform_content_type_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "postDate",
+            "platform",
+            "contentType"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/src/database/migrations/meta/_journal.json
+++ b/src/database/migrations/meta/_journal.json
@@ -36,6 +36,13 @@
       "when": 1780923877531,
       "tag": "0004_gigantic_blackheart",
       "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "7",
+      "when": 1781093898658,
+      "tag": "0005_socials_images",
+      "breakpoints": true
     }
   ]
 }

--- a/src/database/schemas/index.ts
+++ b/src/database/schemas/index.ts
@@ -4,6 +4,7 @@ export { citiesTable as cities } from './cities.schema';
 export { countriesTable as countries } from './countries.schema';
 export { directorsTable as directors } from './directors.schema';
 export { genresTable as genres } from './genres.schema';
+export { socialsImagesTable as socials_images } from './socials_images.schema';
 export { socialsPostsTable as socials_posts } from './socials_posts.schema';
 export { moviesTable as movies } from './movies.schema';
 export { moviesActorsTable as movies_actors } from './movies_actors.schema';

--- a/src/database/schemas/socials_images.schema.ts
+++ b/src/database/schemas/socials_images.schema.ts
@@ -1,0 +1,25 @@
+import {
+  customType,
+  pgTable,
+  timestamp,
+  uuid,
+  varchar,
+} from 'drizzle-orm/pg-core';
+
+const bytea = customType<{ data: Buffer }>({
+  dataType() {
+    return 'bytea';
+  },
+});
+
+// Short-lived storage for rendered social media images: Instagram ingests
+// media from a public URL, so the rendered JPEG is parked here just long
+// enough for the Graph API to fetch it. Rows are pruned on insert.
+export const socialsImagesTable = pgTable('socials_images', {
+  id: uuid().primaryKey().defaultRandom(),
+  data: bytea('data').notNull(),
+  contentType: varchar({ length: 100 }).notNull(),
+  createdAt: timestamp().notNull().defaultNow(),
+});
+
+export type SocialsImage = typeof socialsImagesTable.$inferSelect;

--- a/src/socials/socials.constants.ts
+++ b/src/socials/socials.constants.ts
@@ -1,6 +1,10 @@
 export const CLASSIC_YEAR_THRESHOLD = 2000;
 export const DEEP_CLASSIC_YEAR_THRESHOLD = 1980;
 
+// A movie already posted on a platform within this window is excluded from
+// new candidates, so consecutive posts never repeat the same movie.
+export const REPEAT_COOLDOWN_DAYS = 30;
+
 export const SCORE = {
   DEEP_CLASSIC: 30,
   CLASSIC: 20,

--- a/src/socials/socials.controller.ts
+++ b/src/socials/socials.controller.ts
@@ -1,14 +1,29 @@
 import {
+  BadRequestException,
   Body,
   Controller,
   Get,
   HttpCode,
   HttpStatus,
+  Param,
+  ParseUUIDPipe,
   Post,
   Query,
+  Res,
+  UploadedFile,
   UseGuards,
+  UseInterceptors,
 } from '@nestjs/common';
+import { FileInterceptor } from '@nestjs/platform-express';
+import type { Response } from 'express';
 import { InternalApiKeyGuard } from '../guards/internal-api-key.guard';
+
+// Minimal shape of a multer memory-storage file (@types/multer not installed).
+type UploadedImageFile = {
+  buffer: Buffer;
+  mimetype: string;
+  size: number;
+};
 import type { SocialsGetCandidateResponse } from './socials.types';
 import { GetSocialCandidateQueryDto } from './dto/get-socials-candidate-query.dto';
 import { SocialsService } from './socials.service';
@@ -38,5 +53,32 @@ export class SocialsController {
   @UseGuards(InternalApiKeyGuard)
   publish(@Body() body: SocialsActionDto): Promise<void> {
     return this.socialsService.publishCandidate(body);
+  }
+
+  @Post('image')
+  @UseGuards(InternalApiKeyGuard)
+  @UseInterceptors(
+    FileInterceptor('file', { limits: { fileSize: 15 * 1024 * 1024 } }),
+  )
+  uploadImage(
+    @UploadedFile() file: UploadedImageFile | undefined,
+  ): Promise<{ id: string }> {
+    if (!file) {
+      throw new BadRequestException('file is required');
+    }
+    return this.socialsService.storeImage(file.buffer, file.mimetype);
+  }
+
+  // Public on purpose: Instagram's Graph API downloads the media from this
+  // URL when ingesting a post.
+  @Get('image/:id')
+  async getImage(
+    @Param('id', ParseUUIDPipe) id: string,
+    @Res() res: Response,
+  ): Promise<void> {
+    const image = await this.socialsService.getImage(id);
+    res.setHeader('Content-Type', image.contentType);
+    res.setHeader('Cache-Control', 'public, max-age=86400');
+    res.send(image.data);
   }
 }

--- a/src/socials/socials.repository.ts
+++ b/src/socials/socials.repository.ts
@@ -5,6 +5,8 @@ import * as relations from '../database/schemas/relations';
 import { DRIZZLE } from '../database/constants';
 import { and, asc, eq, gte, inArray, lt, lte } from 'drizzle-orm';
 
+const IMAGE_RETENTION_MS = 48 * 60 * 60 * 1000;
+
 type FullSchema = typeof schema & typeof relations;
 
 @Injectable()
@@ -25,6 +27,15 @@ export class SocialsRepository {
       where: and(
         gte(schema.socials_posts.postDate, dateFrom),
         lte(schema.socials_posts.postDate, dateTo),
+        eq(schema.socials_posts.platform, platform),
+      ),
+    });
+  }
+
+  async findRecentPostsByPlatform(platform: string, sincePostDate: string) {
+    return this.db.query.socials_posts.findMany({
+      where: and(
+        gte(schema.socials_posts.postDate, sincePostDate),
         eq(schema.socials_posts.platform, platform),
       ),
     });
@@ -85,7 +96,36 @@ export class SocialsRepository {
     });
   }
 
+  async findImageById(id: string) {
+    return this.db.query.socials_images.findFirst({
+      where: eq(schema.socials_images.id, id),
+    });
+  }
+
   // === WRITE ===
+
+  async insertImage(
+    data: Buffer,
+    contentType: string,
+  ): Promise<{ id: string }> {
+    // Images are only needed until Instagram ingests them - prune stale
+    // rows on every insert so the table never grows.
+    await this.db
+      .delete(schema.socials_images)
+      .where(
+        lt(
+          schema.socials_images.createdAt,
+          new Date(Date.now() - IMAGE_RETENTION_MS),
+        ),
+      );
+
+    const [row] = await this.db
+      .insert(schema.socials_images)
+      .values({ data, contentType })
+      .returning({ id: schema.socials_images.id });
+
+    return row;
+  }
 
   async upsertPost(values: {
     postDate: string;

--- a/src/socials/socials.service.spec.ts
+++ b/src/socials/socials.service.spec.ts
@@ -80,6 +80,7 @@ describe('SocialsService', () => {
           provide: SocialsRepository,
           useValue: {
             findPostsByDateAndPlatform: jest.fn(),
+            findRecentPostsByPlatform: jest.fn(),
             findScreeningsInRange: jest.fn(),
             findScreeningsByIds: jest.fn(),
             findScreeningById: jest.fn(),
@@ -93,6 +94,7 @@ describe('SocialsService', () => {
 
     service = module.get(SocialsService);
     repo = module.get(SocialsRepository);
+    repo.findRecentPostsByPlatform.mockResolvedValue([]);
   });
 
   describe('getCandidate', () => {
@@ -112,6 +114,40 @@ describe('SocialsService', () => {
       expect(result.candidates).toEqual([]);
       expect(result.meta.bestScore).toBeNull();
       expect(repo.findScreeningsInRange).not.toHaveBeenCalled();
+    });
+
+    it('should skip movies posted on the platform within the cooldown window', async () => {
+      const recentMovie = makeScreening({
+        id: 5,
+        movieId: 1,
+        movie: makeMovie({ id: 1, productionYear: 1975 }),
+      });
+      const freshMovie = makeScreening({
+        id: 6,
+        movieId: 2,
+        movie: makeMovie({ id: 2, productionYear: 1976 }),
+      });
+
+      repo.findPostsByDateAndPlatform.mockResolvedValue([]);
+      repo.findRecentPostsByPlatform.mockResolvedValue([
+        { id: 99, movieId: 1 },
+      ] as any);
+      repo.findScreeningsInRange.mockResolvedValue([
+        recentMovie,
+        freshMovie,
+      ] as any);
+      repo.findScreeningsByIds.mockResolvedValue([freshMovie] as any);
+
+      const result = await service.getCandidate({
+        dateFrom: '2025-03-10',
+        dateTo: '2025-03-12',
+        minScore: 20,
+        platform: 'instagram',
+        numberOfCandidates: 10,
+      });
+
+      expect(result.candidates).toHaveLength(1);
+      expect(result.candidates[0].movieId).toBe(2);
     });
 
     it('should return NO_SCREENINGS_IN_RANGE when no screenings found', async () => {

--- a/src/socials/socials.service.ts
+++ b/src/socials/socials.service.ts
@@ -13,6 +13,7 @@ import {
 import {
   CLASSIC_YEAR_THRESHOLD,
   DEEP_CLASSIC_YEAR_THRESHOLD,
+  REPEAT_COOLDOWN_DAYS,
   SCORE,
 } from './socials.constants';
 import type {
@@ -66,10 +67,23 @@ export class SocialsService {
       dateToNextDay,
     );
 
+    // Movies posted on this platform within the cooldown window are not
+    // eligible again - prevents the same movie appearing in back-to-back
+    // posts when its screenings span multiple date ranges.
+    const cooldownStart = getDatePlusDays(
+      getTodayInPoland(),
+      -REPEAT_COOLDOWN_DAYS,
+    );
+    const recentPosts = await this.repo.findRecentPostsByPlatform(
+      platform,
+      cooldownStart,
+    );
+    const recentMovieIds = new Set(recentPosts.map((post) => post.movieId));
+
     const scoredCandidates = this.computeScoredCandidates(
       screenings,
       numberOfCandidates,
-    );
+    ).filter((candidate) => !recentMovieIds.has(candidate.movieId));
 
     if (screenings.length === 0) {
       return {
@@ -160,6 +174,21 @@ export class SocialsService {
       published: false,
       reason: 'RESERVED',
     });
+  }
+
+  async storeImage(
+    data: Buffer,
+    contentType: string,
+  ): Promise<{ id: string }> {
+    return this.repo.insertImage(data, contentType);
+  }
+
+  async getImage(id: string) {
+    const image = await this.repo.findImageById(id);
+    if (!image) {
+      throw new NotFoundException('Image not found');
+    }
+    return image;
   }
 
   async publishCandidate(dto: SocialsActionDto): Promise<void> {


### PR DESCRIPTION
- POST /socials/image (internal key, multipart, 15MB limit) stores rendered social images in Postgres (bytea); public GET /socials/image/:id serves them so Instagram Graph API can ingest media without external hosting; rows older than 48h are pruned on insert. Migration: 0005_socials_images.sql.
- getCandidate excludes movies already posted on the platform within the last 30 days (REPEAT_COOLDOWN_DAYS), preventing back-to-back posts of the same movie when its screenings span multiple date ranges.

Tests: 45/45 passing in src/socials.

🤖 Generated with [Claude Code](https://claude.com/claude-code)