### PR TITLE
chore: sync main into dev

### DIFF
--- a/.github/rulesets/README.md
+++ b/.github/rulesets/README.md
@@ -1,0 +1,18 @@
+# Branch rulesets
+
+Wersjonowane źródło prawdy dla rulesetów GitHuba (Settings → Rules → Rulesets).
+GitHub nie czyta tych plików automatycznie — po zmianie zastosuj przez `gh`:
+
+```bash
+# aktualizacja istniejącego rulesetu
+gh api repos/klaps-hq/api.klaps.space/rulesets/13251477 --method PUT --input .github/rulesets/main.json
+gh api repos/klaps-hq/api.klaps.space/rulesets/13251471 --method PUT --input .github/rulesets/dev.json
+
+# utworzenie od zera (np. po skasowaniu)
+gh api repos/klaps-hq/api.klaps.space/rulesets --method POST --input .github/rulesets/main.json
+```
+
+| Plik        | Ruleset                   | ID       |
+| ----------- | ------------------------- | -------- |
+| `main.json` | main - PR required checks | 13251477 |
+| `dev.json`  | dev - PR required checks  | 13251471 |

--- a/.github/rulesets/dev.json
+++ b/.github/rulesets/dev.json
@@ -1,0 +1,74 @@
+{
+    "name":  "dev - PR required checks",
+    "target":  "branch",
+    "enforcement":  "active",
+    "conditions":  {
+                       "ref_name":  {
+                                        "exclude":  [
+
+                                                    ],
+                                        "include":  [
+                                                        "refs/heads/dev"
+                                                    ]
+                                    }
+                   },
+    "rules":  [
+                  {
+                      "type":  "deletion"
+                  },
+                  {
+                      "type":  "non_fast_forward"
+                  },
+                  {
+                      "type":  "pull_request",
+                      "parameters":  {
+                                         "required_approving_review_count":  0,
+                                         "dismiss_stale_reviews_on_push":  false,
+                                         "required_reviewers":  [
+
+                                                                ],
+                                         "require_code_owner_review":  false,
+                                         "require_last_push_approval":  false,
+                                         "required_review_thread_resolution":  true,
+                                         "allowed_merge_methods":  [
+                                                                       "merge",
+                                                                       "squash",
+                                                                       "rebase"
+                                                                   ]
+                                     }
+                  },
+                  {
+                      "type":  "required_status_checks",
+                      "parameters":  {
+                                         "strict_required_status_checks_policy":  false,
+                                         "do_not_enforce_on_create":  false,
+                                         "required_status_checks":  [
+                                                                        {
+                                                                            "context":  "build",
+                                                                            "integration_id":  15368
+                                                                        },
+                                                                        {
+                                                                            "context":  "PR Title (Conventional)",
+                                                                            "integration_id":  15368
+                                                                        },
+                                                                        {
+                                                                            "context":  "typecheck",
+                                                                            "integration_id":  15368
+                                                                        },
+                                                                        {
+                                                                            "context":  "Commit Messages (Conventional)",
+                                                                            "integration_id":  15368
+                                                                        },
+                                                                        {
+                                                                            "context":  "test",
+                                                                            "integration_id":  15368
+                                                                        },
+                                                                        {
+                                                                            "context":  "Auto-format PR title",
+                                                                            "integration_id":  15368
+                                                                        }
+                                                                    ]
+                                     }
+                  }
+              ]
+}

--- a/.github/rulesets/main.json
+++ b/.github/rulesets/main.json
@@ -1,0 +1,74 @@
+{
+    "name":  "main - PR required checks",
+    "target":  "branch",
+    "enforcement":  "active",
+    "conditions":  {
+                       "ref_name":  {
+                                        "exclude":  [
+
+                                                    ],
+                                        "include":  [
+                                                        "refs/heads/main"
+                                                    ]
+                                    }
+                   },
+    "rules":  [
+                  {
+                      "type":  "deletion"
+                  },
+                  {
+                      "type":  "non_fast_forward"
+                  },
+                  {
+                      "type":  "pull_request",
+                      "parameters":  {
+                                         "required_approving_review_count":  0,
+                                         "dismiss_stale_reviews_on_push":  false,
+                                         "required_reviewers":  [
+
+                                                                ],
+                                         "require_code_owner_review":  false,
+                                         "require_last_push_approval":  false,
+                                         "required_review_thread_resolution":  true,
+                                         "allowed_merge_methods":  [
+                                                                       "merge",
+                                                                       "squash",
+                                                                       "rebase"
+                                                                   ]
+                                     }
+                  },
+                  {
+                      "type":  "required_status_checks",
+                      "parameters":  {
+                                         "strict_required_status_checks_policy":  false,
+                                         "do_not_enforce_on_create":  false,
+                                         "required_status_checks":  [
+                                                                        {
+                                                                            "context":  "build",
+                                                                            "integration_id":  15368
+                                                                        },
+                                                                        {
+                                                                            "context":  "Auto-format PR title",
+                                                                            "integration_id":  15368
+                                                                        },
+                                                                        {
+                                                                            "context":  "PR Title (Conventional)",
+                                                                            "integration_id":  15368
+                                                                        },
+                                                                        {
+                                                                            "context":  "typecheck",
+                                                                            "integration_id":  15368
+                                                                        },
+                                                                        {
+                                                                            "context":  "Commit Messages (Conventional)",
+                                                                            "integration_id":  15368
+                                                                        },
+                                                                        {
+                                                                            "context":  "test",
+                                                                            "integration_id":  15368
+                                                                        }
+                                                                    ]
+                                     }
+                  }
+              ]
+}


### PR DESCRIPTION
Aligns `dev` with `main` (versioned branch rulesets from #50). No source changes — `dev` already contains everything else.

🤖 Generated with [Claude Code](https://claude.com/claude-code)