### PR TITLE
chore: merge dev into main

### DIFF
--- a/src/socials/dto/get-socials-candidate-query.dto.ts
+++ b/src/socials/dto/get-socials-candidate-query.dto.ts
@@ -4,6 +4,7 @@ import {
   IsDateString,
   IsIn,
   IsInt,
+  IsOptional,
   IsString,
   Matches,
   Max,
@@ -44,6 +45,15 @@ export class GetSocialCandidateQueryDto {
   @Min(0)
   @Max(100, { message: 'numberOfCandidates must be at most 100' })
   numberOfCandidates: number;
+
+  @IsOptional()
+  @Transform(({ value }: { value: unknown }) =>
+    value === undefined ? undefined : Number(value),
+  )
+  @IsInt()
+  @Min(1)
+  @Max(10, { message: 'maxPosts must be at most 10' })
+  maxPosts?: number;
 
   @IsString()
   @Transform(({ value }: { value: unknown }) =>

--- a/src/socials/socials.service.spec.ts
+++ b/src/socials/socials.service.spec.ts
@@ -116,6 +116,43 @@ describe('SocialsService', () => {
       expect(repo.findScreeningsInRange).not.toHaveBeenCalled();
     });
 
+    it('should allow another post when fewer posts exist than maxPosts', async () => {
+      repo.findPostsByDateAndPlatform.mockResolvedValue([{ id: 1 }] as any);
+      repo.findScreeningsInRange.mockResolvedValue([]);
+
+      const result = await service.getCandidate({
+        dateFrom: '2025-03-10',
+        dateTo: '2025-03-12',
+        minScore: 20,
+        platform: 'instagram',
+        numberOfCandidates: 10,
+        maxPosts: 2,
+      });
+
+      expect(result.reason).not.toBe('ALREADY_PUBLISHED');
+      expect(repo.findScreeningsInRange).toHaveBeenCalled();
+    });
+
+    it('should return ALREADY_PUBLISHED when posts reach maxPosts', async () => {
+      repo.findPostsByDateAndPlatform.mockResolvedValue([
+        { id: 1 },
+        { id: 2 },
+      ] as any);
+
+      const result = await service.getCandidate({
+        dateFrom: '2025-03-10',
+        dateTo: '2025-03-12',
+        minScore: 20,
+        platform: 'instagram',
+        numberOfCandidates: 10,
+        maxPosts: 2,
+      });
+
+      expect(result.publish).toBe(false);
+      expect(result.reason).toBe('ALREADY_PUBLISHED');
+      expect(repo.findScreeningsInRange).not.toHaveBeenCalled();
+    });
+
     it('should skip movies posted on the platform within the cooldown window', async () => {
       const recentMovie = makeScreening({
         id: 5,

--- a/src/socials/socials.service.ts
+++ b/src/socials/socials.service.ts
@@ -39,6 +39,10 @@ export class SocialsService {
     const minScore = query.minScore;
     const platform = query.platform;
     const numberOfCandidates = query.numberOfCandidates ?? 10;
+    // How many posts may already exist in the range before publishing stops.
+    // Lets a platform run several slots per day (e.g. two stories) while the
+    // movie cooldown below keeps the slots from repeating the same movie.
+    const maxPosts = query.maxPosts ?? 1;
 
     const socialsPosts = await this.repo.findPostsByDateAndPlatform(
       dateFrom,
@@ -46,7 +50,7 @@ export class SocialsService {
       platform,
     );
 
-    if (socialsPosts.length > 0) {
+    if (socialsPosts.length >= maxPosts) {
       return {
         publish: false,
         date: { from: dateFrom, to: dateTo },


### PR DESCRIPTION
Releases the `maxPosts` candidate param (#51) to production. The radar scheduler already sends `maxPosts` for story jobs, and the production API rejects unknown params (`forbidNonWhitelisted`), so story slots will fail with 400 until this is deployed.