### PR TITLE
feat(socials): rating-aware candidate scoring with breakdown

### DIFF
--- a/src/socials/socials.constants.ts
+++ b/src/socials/socials.constants.ts
@@ -11,4 +11,22 @@ export const SCORE = {
   NORMAL_YEAR: 10,
   MULTI_CITY: 20,
   MULTI_GENRE: 10,
+  // Filmweb users rating contributes up to this many points, scaled by both
+  // the rating itself and how many votes back it, so a widely known 8.0
+  // outranks an obscure 8.0 and ties between classics stop being arbitrary.
+  RATING_MAX: 25,
+  CRITICS_BONUS: 5,
 } as const;
+
+// Users rating at or below the baseline scores 0; at or above the ceiling it
+// scores the full quality factor.
+export const RATING_QUALITY_BASELINE = 5;
+export const RATING_QUALITY_CEILING = 8;
+
+// Vote-count confidence saturates at 10^5 (100k votes -> full confidence).
+export const RATING_VOTES_CEILING_LOG10 = 5;
+
+// Critics bonus applies only to well-reviewed movies with enough reviews to
+// trust the number.
+export const CRITICS_BONUS_MIN_RATING = 7;
+export const CRITICS_BONUS_MIN_VOTES = 5;

--- a/src/socials/socials.service.spec.ts
+++ b/src/socials/socials.service.spec.ts
@@ -16,6 +16,11 @@ const makeMovie = (
     id: number;
     productionYear: number;
     movies_genres: { id: number; genreId: number }[];
+    backdropUrl: string | null;
+    usersRating: number | null;
+    usersRatingVotes: number | null;
+    criticsRating: number | null;
+    criticsRatingVotes: number | null;
   }> = {},
 ) => ({
   id: overrides.id ?? 1,
@@ -28,15 +33,18 @@ const makeMovie = (
   duration: 120,
   language: 'pl',
   posterUrl: null,
-  backdropUrl: null,
+  backdropUrl:
+    overrides.backdropUrl === undefined
+      ? 'https://example.com/backdrop.jpg'
+      : overrides.backdropUrl,
   videoUrl: null,
   url: 'https://example.com/movie',
   worldPremiereDate: null,
   polishPremiereDate: null,
-  usersRating: null,
-  usersRatingVotes: null,
-  criticsRating: null,
-  criticsRatingVotes: null,
+  usersRating: overrides.usersRating ?? null,
+  usersRatingVotes: overrides.usersRatingVotes ?? null,
+  criticsRating: overrides.criticsRating ?? null,
+  criticsRatingVotes: overrides.criticsRatingVotes ?? null,
   boxoffice: null,
   budget: null,
   distribution: null,
@@ -375,6 +383,140 @@ describe('SocialsService', () => {
 
       const result = await runScoring([screening]);
       expect(result.meta.bestScore).toBe(30);
+    });
+
+    it('should exclude movies without a backdrop image', async () => {
+      const noBackdrop = makeScreening({
+        id: 1,
+        movieId: 1,
+        movie: makeMovie({ id: 1, productionYear: 1975, backdropUrl: null }),
+      });
+      const withBackdrop = makeScreening({
+        id: 2,
+        movieId: 2,
+        movie: makeMovie({ id: 2, productionYear: 2020 }),
+      });
+
+      const result = await runScoring([noBackdrop, withBackdrop]);
+
+      // The deep classic would win, but without artwork it is not a
+      // candidate at all - the modern movie is the only one left.
+      expect(result.meta.candidatesChecked).toBe(1);
+      expect(result.meta.bestScore).toBe(10);
+    });
+
+    it('should award up to 25 rating points scaled by votes', async () => {
+      const screening = makeScreening({
+        id: 1,
+        movieId: 1,
+        movie: makeMovie({
+          id: 1,
+          productionYear: 1975,
+          usersRating: 8.0,
+          usersRatingVotes: 100000,
+        }),
+      });
+
+      const result = await runScoring([screening]);
+      // 30 (deep classic) + 25 (rating 8.0 at full vote confidence)
+      expect(result.meta.bestScore).toBe(55);
+    });
+
+    it('should scale rating points down for few votes', async () => {
+      const screening = makeScreening({
+        id: 1,
+        movieId: 1,
+        movie: makeMovie({
+          id: 1,
+          productionYear: 1975,
+          usersRating: 8.0,
+          usersRatingVotes: 100,
+        }),
+      });
+
+      const result = await runScoring([screening]);
+      // 30 + round(25 * 1.0 * (log10(100) / 5)) = 30 + 10
+      expect(result.meta.bestScore).toBe(40);
+    });
+
+    it('should award no rating points at or below the quality baseline', async () => {
+      const screening = makeScreening({
+        id: 1,
+        movieId: 1,
+        movie: makeMovie({
+          id: 1,
+          productionYear: 1975,
+          usersRating: 5.0,
+          usersRatingVotes: 100000,
+        }),
+      });
+
+      const result = await runScoring([screening]);
+      expect(result.meta.bestScore).toBe(30);
+    });
+
+    it('should award the critics bonus only for well-reviewed movies', async () => {
+      const wellReviewed = makeScreening({
+        id: 1,
+        movieId: 1,
+        movie: makeMovie({
+          id: 1,
+          productionYear: 1975,
+          criticsRating: 7.5,
+          criticsRatingVotes: 10,
+        }),
+      });
+      const fewReviews = makeScreening({
+        id: 2,
+        movieId: 2,
+        movie: makeMovie({
+          id: 2,
+          productionYear: 1975,
+          criticsRating: 9.0,
+          criticsRatingVotes: 2,
+        }),
+      });
+
+      const result = await runScoring([wellReviewed, fewReviews]);
+
+      const scoring = result.meta.scoring!;
+      const byMovie = new Map(scoring.map((s) => [s.movieId, s]));
+      expect(byMovie.get(1)!.score).toBe(35);
+      expect(byMovie.get(1)!.breakdown.critics).toBe(5);
+      expect(byMovie.get(2)!.score).toBe(30);
+      expect(byMovie.get(2)!.breakdown.critics).toBe(0);
+    });
+
+    it('should expose the score breakdown in meta.scoring', async () => {
+      const screening = makeScreening({
+        id: 1,
+        movieId: 1,
+        movie: makeMovie({
+          id: 1,
+          productionYear: 1975,
+          usersRating: 8.0,
+          usersRatingVotes: 100000,
+          movies_genres: [
+            { id: 1, genreId: 1 },
+            { id: 2, genreId: 2 },
+          ],
+        }),
+      });
+
+      const result = await runScoring([screening]);
+
+      expect(result.meta.scoring![0]).toEqual({
+        movieId: 1,
+        screeningId: 1,
+        score: 65,
+        breakdown: {
+          year: 30,
+          multiCity: 0,
+          multiGenre: 10,
+          rating: 25,
+          critics: 0,
+        },
+      });
     });
 
     it('should award 30 points for year exactly 1980', async () => {

--- a/src/socials/socials.service.ts
+++ b/src/socials/socials.service.ts
@@ -12,7 +12,12 @@ import {
 } from '../lib/date';
 import {
   CLASSIC_YEAR_THRESHOLD,
+  CRITICS_BONUS_MIN_RATING,
+  CRITICS_BONUS_MIN_VOTES,
   DEEP_CLASSIC_YEAR_THRESHOLD,
+  RATING_QUALITY_BASELINE,
+  RATING_QUALITY_CEILING,
+  RATING_VOTES_CEILING_LOG10,
   REPEAT_COOLDOWN_DAYS,
   SCORE,
 } from './socials.constants';
@@ -108,11 +113,12 @@ export class SocialsService {
     const bestScore = bestCandidate?.score ?? null;
     const hasHighQualityCandidate = bestScore !== null && bestScore >= minScore;
 
-    const candidates = sortedCandidates.map(
-      ({ movieId, screeningId, score }) => ({
+    const candidates: ScoredCandidate[] = sortedCandidates.map(
+      ({ movieId, screeningId, score, breakdown }) => ({
         movieId,
         screeningId,
         score,
+        breakdown,
       }),
     );
 
@@ -140,6 +146,7 @@ export class SocialsService {
         candidatesChecked: scoredCandidates.length,
         bestScore,
         minScore,
+        scoring: candidates,
       },
       candidates: orderedCandidates,
     };
@@ -243,30 +250,44 @@ export class SocialsService {
       const { movieId, movie, id: screeningId } = screening;
       if (!movie) continue;
 
-      let score = 0;
-      const year = movie.productionYear;
+      // Posts are image-first: without a backdrop there is nothing to render,
+      // so the movie cannot be a candidate at all.
+      if (!movie.backdropUrl) continue;
 
-      if (year <= DEEP_CLASSIC_YEAR_THRESHOLD) {
-        score += SCORE.DEEP_CLASSIC;
-      } else if (year <= CLASSIC_YEAR_THRESHOLD) {
-        score += SCORE.CLASSIC;
-      } else {
-        score += SCORE.NORMAL_YEAR;
-      }
+      const year = movie.productionYear;
+      const yearScore =
+        year <= DEEP_CLASSIC_YEAR_THRESHOLD
+          ? SCORE.DEEP_CLASSIC
+          : year <= CLASSIC_YEAR_THRESHOLD
+            ? SCORE.CLASSIC
+            : SCORE.NORMAL_YEAR;
 
       const genreCount = movie.movies_genres?.length ?? 0;
-      if (genreCount > 1) {
-        score += SCORE.MULTI_GENRE;
-      }
+      const multiGenreScore = genreCount > 1 ? SCORE.MULTI_GENRE : 0;
 
       const cityCount = cityIdsByMovieId.get(movieId)?.size ?? 0;
-      if (cityCount > 1) {
-        score += SCORE.MULTI_CITY;
-      }
+      const multiCityScore = cityCount > 1 ? SCORE.MULTI_CITY : 0;
+
+      const { rating, critics } = this.computeRatingScore(movie);
+
+      const breakdown = {
+        year: yearScore,
+        multiCity: multiCityScore,
+        multiGenre: multiGenreScore,
+        rating,
+        critics,
+      };
+      const score =
+        yearScore + multiCityScore + multiGenreScore + rating + critics;
 
       const existing = candidatesByMovie.get(movieId);
       if (!existing || score > existing.score) {
-        candidatesByMovie.set(movieId, { movieId, screeningId, score });
+        candidatesByMovie.set(movieId, {
+          movieId,
+          screeningId,
+          score,
+          breakdown,
+        });
       }
     }
 
@@ -276,10 +297,50 @@ export class SocialsService {
 
     return sortedCandidates
       .slice(0, numberOfCandidates)
-      .map(([movieId, { screeningId, score }]) => ({
+      .map(([movieId, { screeningId, score, breakdown }]) => ({
         movieId,
         screeningId,
         score,
+        breakdown,
       }));
+  }
+
+  // Users rating contributes up to SCORE.RATING_MAX points: a quality factor
+  // (how far the rating sits above the baseline) scaled by a confidence
+  // factor (log of the vote count), so a widely rated classic beats an
+  // obscure movie with the same rating. Well-reviewed movies with enough
+  // critic votes get a small flat bonus on top.
+  private computeRatingScore(movie: {
+    usersRating: number | null;
+    usersRatingVotes: number | null;
+    criticsRating: number | null;
+    criticsRatingVotes: number | null;
+  }): { rating: number; critics: number } {
+    let rating = 0;
+
+    if (movie.usersRating !== null && (movie.usersRatingVotes ?? 0) > 0) {
+      const quality = Math.min(
+        1,
+        Math.max(
+          0,
+          (movie.usersRating - RATING_QUALITY_BASELINE) /
+            (RATING_QUALITY_CEILING - RATING_QUALITY_BASELINE),
+        ),
+      );
+      const confidence = Math.min(
+        1,
+        Math.log10(movie.usersRatingVotes!) / RATING_VOTES_CEILING_LOG10,
+      );
+      rating = Math.round(SCORE.RATING_MAX * quality * confidence);
+    }
+
+    const critics =
+      movie.criticsRating !== null &&
+      movie.criticsRating >= CRITICS_BONUS_MIN_RATING &&
+      (movie.criticsRatingVotes ?? 0) >= CRITICS_BONUS_MIN_VOTES
+        ? SCORE.CRITICS_BONUS
+        : 0;
+
+    return { rating, critics };
   }
 }

--- a/src/socials/socials.types.ts
+++ b/src/socials/socials.types.ts
@@ -1,10 +1,21 @@
 import type { Screening } from '../screenings/screenings.types';
 import type { Movie } from '../movies/movies.types';
 
+// Per-signal score breakdown, exposed in the response meta so scoring can be
+// tuned against real data instead of guessing.
+export type ScoreBreakdown = {
+  year: number;
+  multiCity: number;
+  multiGenre: number;
+  rating: number;
+  critics: number;
+};
+
 export type ScoredCandidate = {
   movieId: number;
   screeningId: number;
   score: number;
+  breakdown: ScoreBreakdown;
 };
 
 export type ScreeningWithCinemaCity = Screening & {
@@ -18,6 +29,7 @@ export type CandidateByMovieSet = {
   screeningId: number;
   movieId: number;
   score: number;
+  breakdown: ScoreBreakdown;
 };
 
 export type SocialsGetCandidateResponse = {
@@ -32,6 +44,7 @@ export type SocialsGetCandidateResponse = {
     candidatesChecked: number;
     bestScore: number | null;
     minScore: number;
+    scoring?: ScoredCandidate[];
   };
   candidates: ScreeningWithCinemaCity[];
 };


### PR DESCRIPTION
## Problem
Candidate scoring used three coarse signals (year bucket, multi-city, multi-genre), giving only six possible scores. Most classics tied at 60 points and the winner among them was effectively database insertion order. Recognizable, highly rated classics scored the same as obscure titles, and movies without artwork could win even though posts are image-first.

## Solution
- **Rating points (0-25)**: Filmweb users rating quality (above 5.0, saturating at 8.0) scaled by vote-count confidence (log10, saturating at 100k votes).
- **Critics bonus (+5)** for movies rated >= 7 by >= 5 critics.
- **Backdrop gate**: movies without `backdropUrl` are excluded (nothing to render).
- **`meta.scoring`**: per-candidate score breakdown in the response for tuning against real data.

Existing signals (year, multi-city, multi-genre) and the API contract are unchanged; `meta.scoring` is additive, so the radar needs no changes.

## Simulated on live production data (37 candidates)
| Movie | Old rank | New rank |
|---|---|---|
| Ojciec chrzestny (8.7, 23k votes) | 1 | 1 |
| Osiem i pol (8.1) | 11 | 3 |
| Viridiana (7.7) | 24 | 7 |
| Lowca androidow (7.9, 15k) | 22 | 10 |
| Giulietta od duchow (7.2, 338 votes) | 4 | 11 |
| Czlowiek z marmuru (7.0, 91 votes) | 7 | 13 |

Tests: 53 socials tests pass (6 new), 299 total.