### PR TITLE
feat: include directors in random-screening movie hero

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,6 @@ pids
 # Diagnostic reports (https://nodejs.org/api/report.html)
 report.[0-9]*.[0-9]*.[0-9]*.[0-9]*.json
 CLAUDE.md
+
+# Local data dumps
+cinemas.json

--- a/src/movies/movies.mapper.ts
+++ b/src/movies/movies.mapper.ts
@@ -56,9 +56,28 @@ export const mapMovieSummary = (
   ...(updatedAt !== undefined && { updatedAt: updatedAt.toISOString() }),
 });
 
-export const mapMovieHero = (movie: DbMovieWithGenres): MovieHeroResponse => ({
+type DbMovieWithDirectors = DbMovieWithGenres & {
+  movies_directors?: Array<{
+    director: { id: number; slug: string | null; name: string };
+  }>;
+};
+
+export const mapMovieHero = (
+  movie: DbMovieWithDirectors,
+): MovieHeroResponse => ({
   ...mapMovieSummary(movie),
   backdropUrl: movie.backdropUrl ?? null,
+  // Directors are optional: only callers that load the relation get them
+  // (the home hero links the director like the cinema and city).
+  ...(movie.movies_directors && {
+    directors: movie.movies_directors.map(
+      ({ director: { id, slug, name } }) => ({
+        id,
+        slug: slug ?? null,
+        name,
+      }),
+    ),
+  }),
 });
 
 const formatDateField = (

--- a/src/movies/movies.types.ts
+++ b/src/movies/movies.types.ts
@@ -35,6 +35,8 @@ export type MovieSummaryResponse = {
 
 export type MovieHeroResponse = MovieSummaryResponse & {
   backdropUrl: string | null;
+  /** Present only when the caller loaded the directors relation. */
+  directors?: { id: number; slug: string | null; name: string }[];
 };
 
 export type MovieResponse = {

--- a/src/screenings/screenings.repository.spec.ts
+++ b/src/screenings/screenings.repository.spec.ts
@@ -410,6 +410,7 @@ describe('ScreeningsRepository', () => {
         where: expect.anything(),
         with: {
           movies_genres: { with: { genre: true } },
+          movies_directors: { with: { director: true } },
           screenings: {
             where: expect.anything(),
             with: { cinema: { with: { city: true } } },

--- a/src/screenings/screenings.repository.ts
+++ b/src/screenings/screenings.repository.ts
@@ -168,6 +168,8 @@ export class ScreeningsRepository {
       where: eq(schema.movies.id, movieId),
       with: {
         movies_genres: { with: { genre: true } },
+        // Directors feed the home hero meta line (linked like city/cinema).
+        movies_directors: { with: { director: true } },
         screenings: {
           where: and(
             gte(schema.screenings.date, startDay),


### PR DESCRIPTION
## Summary

- `/screenings/random-screening` now loads the `movies_directors` relation and maps it onto `MovieHeroResponse` as an optional `directors` array (`{ id, slug, name }`).
- Callers that do not load the relation are unaffected (the field is omitted, not null).
- Consumed by klaps.space: the home hero meta line links the director the same way it links the cinema and city.

## Tests

- Full suite passes (34 suites, 299 tests).
- `screenings.repository.spec.ts` updated for the new relation include.

🤖 Generated with [Claude Code](https://claude.com/claude-code)