### PR TITLE
feat(cinemas): add email and website columns with contact import script

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "db:backfill-director-slugs": "bunx ts-node -r dotenv/config src/scripts/backfill-director-slugs.ts",
     "db:backfill-director-photos": "bunx ts-node -r dotenv/config src/scripts/backfill-director-photos.ts",
     "db:backfill-voivodeships": "bunx ts-node -r dotenv/config src/scripts/backfill-voivodeships.ts",
+    "db:import-cinema-contacts": "bunx ts-node -r dotenv/config src/scripts/import-cinema-contacts.ts",
     "db:wipe": "node -r ts-node/register src/scripts/db-wipe.ts",
     "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\"",
     "start": "nest start",

--- a/src/cinemas/cinemas.controller.spec.ts
+++ b/src/cinemas/cinemas.controller.spec.ts
@@ -27,6 +27,7 @@ describe('CinemasController', () => {
     latitude: 52.2463,
     longitude: 21.0027,
     filmwebUrl: 'https://www.filmweb.pl/cinema/kino-muranow',
+    website: null,
   };
 
   beforeEach(async () => {

--- a/src/cinemas/cinemas.mapper.ts
+++ b/src/cinemas/cinemas.mapper.ts
@@ -20,6 +20,7 @@ type DbCinemaWithCity = {
   street: string | null;
   description?: string | null;
   url: string;
+  website?: string | null;
   latitude: number | null;
   longitude: number | null;
   city?: {
@@ -59,4 +60,5 @@ export const mapCinemaDetail = (cinema: DbCinemaWithCity): CinemaResponse => ({
   latitude: cinema.latitude,
   longitude: cinema.longitude,
   filmwebUrl: cinema.url,
+  website: cinema.website ?? null,
 });

--- a/src/cinemas/cinemas.service.spec.ts
+++ b/src/cinemas/cinemas.service.spec.ts
@@ -19,6 +19,8 @@ describe('CinemasService', () => {
     url: 'https://www.filmweb.pl/cinema/kino-muranow',
     latitude: 52.2463,
     longitude: 21.0027,
+    email: null,
+    website: null,
     createdAt: new Date('2025-01-01'),
     updatedAt: new Date('2025-01-01'),
   };

--- a/src/cinemas/cinemas.service.spec.ts
+++ b/src/cinemas/cinemas.service.spec.ts
@@ -174,6 +174,7 @@ describe('CinemasService', () => {
         latitude: 52.2463,
         longitude: 21.0027,
         filmwebUrl: 'https://www.filmweb.pl/cinema/kino-muranow',
+        website: null,
       });
     });
 
@@ -235,6 +236,7 @@ describe('CinemasService', () => {
         latitude: 52.2463,
         longitude: 21.0027,
         filmwebUrl: 'https://www.filmweb.pl/cinema/kino-muranow',
+        website: null,
       });
     });
 

--- a/src/cinemas/cinemas.types.ts
+++ b/src/cinemas/cinemas.types.ts
@@ -23,4 +23,6 @@ export type CinemaResponse = {
   latitude: number | null;
   longitude: number | null;
   filmwebUrl: string;
+  /** The cinema's own official website, when known; null otherwise. */
+  website: string | null;
 };

--- a/src/database/migrations/0007_smooth_marvel_zombies.sql
+++ b/src/database/migrations/0007_smooth_marvel_zombies.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "cinemas" ADD COLUMN "email" varchar(255);--> statement-breakpoint
+ALTER TABLE "cinemas" ADD COLUMN "website" varchar(255);

--- a/src/database/migrations/meta/0007_snapshot.json
+++ b/src/database/migrations/meta/0007_snapshot.json
@@ -1,0 +1,1526 @@
+{
+  "id": "f6f6032c-59a4-4506-8123-f29d44ab3dc7",
+  "prevId": "be685982-b1b9-4ff2-8a37-90c05d91db08",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.actors": {
+      "name": "actors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "sourceId": {
+          "name": "sourceId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "actors_sourceId_unique": {
+          "name": "actors_sourceId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "sourceId"
+          ]
+        },
+        "actors_url_unique": {
+          "name": "actors_url_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "url"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cinemas": {
+      "name": "cinemas",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "sourceId": {
+          "name": "sourceId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sourceCityId": {
+          "name": "sourceCityId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "street": {
+          "name": "street",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "website": {
+          "name": "website",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "cinemas_sourceCityId_cities_sourceId_fk": {
+          "name": "cinemas_sourceCityId_cities_sourceId_fk",
+          "tableFrom": "cinemas",
+          "tableTo": "cities",
+          "columnsFrom": [
+            "sourceCityId"
+          ],
+          "columnsTo": [
+            "sourceId"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "cinemas_sourceId_unique": {
+          "name": "cinemas_sourceId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "sourceId"
+          ]
+        },
+        "cinemas_slug_unique": {
+          "name": "cinemas_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cities": {
+      "name": "cities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "sourceId": {
+          "name": "sourceId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "nameDeclinated": {
+          "name": "nameDeclinated",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "areacode": {
+          "name": "areacode",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "population": {
+          "name": "population",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "voivodeship": {
+          "name": "voivodeship",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastScrapedAt": {
+          "name": "lastScrapedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "cities_sourceId_unique": {
+          "name": "cities_sourceId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "sourceId"
+          ]
+        },
+        "cities_slug_unique": {
+          "name": "cities_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.countries": {
+      "name": "countries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "countryCode": {
+          "name": "countryCode",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "countries_countryCode_unique": {
+          "name": "countries_countryCode_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "countryCode"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.directors": {
+      "name": "directors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "sourceId": {
+          "name": "sourceId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'director'"
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "photoUrl": {
+          "name": "photoUrl",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "directors_sourceId_unique": {
+          "name": "directors_sourceId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "sourceId"
+          ]
+        },
+        "directors_slug_unique": {
+          "name": "directors_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.genres": {
+      "name": "genres",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "sourceId": {
+          "name": "sourceId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "genres_sourceId_unique": {
+          "name": "genres_sourceId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "sourceId"
+          ]
+        },
+        "genres_slug_unique": {
+          "name": "genres_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.movies": {
+      "name": "movies",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "sourceId": {
+          "name": "sourceId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "titleOriginal": {
+          "name": "titleOriginal",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "productionYear": {
+          "name": "productionYear",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "worldPremiereDate": {
+          "name": "worldPremiereDate",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "polishPremiereDate": {
+          "name": "polishPremiereDate",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "usersRating": {
+          "name": "usersRating",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "usersRatingVotes": {
+          "name": "usersRatingVotes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "criticsRating": {
+          "name": "criticsRating",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "criticsRatingVotes": {
+          "name": "criticsRatingVotes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "language": {
+          "name": "language",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "posterUrl": {
+          "name": "posterUrl",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "backdropUrl": {
+          "name": "backdropUrl",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "posterBlurDataUrl": {
+          "name": "posterBlurDataUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "backdropBlurDataUrl": {
+          "name": "backdropBlurDataUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "videoUrl": {
+          "name": "videoUrl",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "boxoffice": {
+          "name": "boxoffice",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "budget": {
+          "name": "budget",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "distribution": {
+          "name": "distribution",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "movies_sourceId_unique": {
+          "name": "movies_sourceId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "sourceId"
+          ]
+        },
+        "movies_slug_unique": {
+          "name": "movies_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.movies_actors": {
+      "name": "movies_actors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "movieId": {
+          "name": "movieId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actorId": {
+          "name": "actorId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "movies_actors_movieId_movies_id_fk": {
+          "name": "movies_actors_movieId_movies_id_fk",
+          "tableFrom": "movies_actors",
+          "tableTo": "movies",
+          "columnsFrom": [
+            "movieId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "movies_actors_actorId_actors_id_fk": {
+          "name": "movies_actors_actorId_actors_id_fk",
+          "tableFrom": "movies_actors",
+          "tableTo": "actors",
+          "columnsFrom": [
+            "actorId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "movies_actors_movieId_actorId_unique": {
+          "name": "movies_actors_movieId_actorId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "movieId",
+            "actorId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.movies_countries": {
+      "name": "movies_countries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "movieId": {
+          "name": "movieId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "countryId": {
+          "name": "countryId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "movies_countries_movieId_movies_id_fk": {
+          "name": "movies_countries_movieId_movies_id_fk",
+          "tableFrom": "movies_countries",
+          "tableTo": "movies",
+          "columnsFrom": [
+            "movieId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "movies_countries_countryId_countries_id_fk": {
+          "name": "movies_countries_countryId_countries_id_fk",
+          "tableFrom": "movies_countries",
+          "tableTo": "countries",
+          "columnsFrom": [
+            "countryId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "movies_countries_movieId_countryId_unique": {
+          "name": "movies_countries_movieId_countryId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "movieId",
+            "countryId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.movies_directors": {
+      "name": "movies_directors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "movieId": {
+          "name": "movieId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "directorId": {
+          "name": "directorId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "movies_directors_movieId_movies_id_fk": {
+          "name": "movies_directors_movieId_movies_id_fk",
+          "tableFrom": "movies_directors",
+          "tableTo": "movies",
+          "columnsFrom": [
+            "movieId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "movies_directors_directorId_directors_id_fk": {
+          "name": "movies_directors_directorId_directors_id_fk",
+          "tableFrom": "movies_directors",
+          "tableTo": "directors",
+          "columnsFrom": [
+            "directorId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "movies_directors_movieId_directorId_unique": {
+          "name": "movies_directors_movieId_directorId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "movieId",
+            "directorId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.movies_genres": {
+      "name": "movies_genres",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "movieId": {
+          "name": "movieId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "genreId": {
+          "name": "genreId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "movies_genres_movieId_movies_id_fk": {
+          "name": "movies_genres_movieId_movies_id_fk",
+          "tableFrom": "movies_genres",
+          "tableTo": "movies",
+          "columnsFrom": [
+            "movieId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "movies_genres_genreId_genres_id_fk": {
+          "name": "movies_genres_genreId_genres_id_fk",
+          "tableFrom": "movies_genres",
+          "tableTo": "genres",
+          "columnsFrom": [
+            "genreId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "movies_genres_movieId_genreId_unique": {
+          "name": "movies_genres_movieId_genreId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "movieId",
+            "genreId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.movies_scriptwriters": {
+      "name": "movies_scriptwriters",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "movieId": {
+          "name": "movieId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scriptwriterId": {
+          "name": "scriptwriterId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "movies_scriptwriters_movieId_movies_id_fk": {
+          "name": "movies_scriptwriters_movieId_movies_id_fk",
+          "tableFrom": "movies_scriptwriters",
+          "tableTo": "movies",
+          "columnsFrom": [
+            "movieId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "movies_scriptwriters_scriptwriterId_scriptwriters_id_fk": {
+          "name": "movies_scriptwriters_scriptwriterId_scriptwriters_id_fk",
+          "tableFrom": "movies_scriptwriters",
+          "tableTo": "scriptwriters",
+          "columnsFrom": [
+            "scriptwriterId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "movies_scriptwriters_movieId_scriptwriterId_unique": {
+          "name": "movies_scriptwriters_movieId_scriptwriterId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "movieId",
+            "scriptwriterId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.screenings": {
+      "name": "screenings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "movieId": {
+          "name": "movieId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "showtimeId": {
+          "name": "showtimeId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cinemaId": {
+          "name": "cinemaId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "isDubbing": {
+          "name": "isDubbing",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "isSubtitled": {
+          "name": "isSubtitled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "screenings_movieId_movies_id_fk": {
+          "name": "screenings_movieId_movies_id_fk",
+          "tableFrom": "screenings",
+          "tableTo": "movies",
+          "columnsFrom": [
+            "movieId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "screenings_showtimeId_showtimes_id_fk": {
+          "name": "screenings_showtimeId_showtimes_id_fk",
+          "tableFrom": "screenings",
+          "tableTo": "showtimes",
+          "columnsFrom": [
+            "showtimeId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "screenings_cinemaId_cinemas_sourceId_fk": {
+          "name": "screenings_cinemaId_cinemas_sourceId_fk",
+          "tableFrom": "screenings",
+          "tableTo": "cinemas",
+          "columnsFrom": [
+            "cinemaId"
+          ],
+          "columnsTo": [
+            "sourceId"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "screenings_unique": {
+          "name": "screenings_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "movieId",
+            "cinemaId",
+            "date",
+            "type",
+            "isDubbing",
+            "isSubtitled"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.scriptwriters": {
+      "name": "scriptwriters",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "sourceId": {
+          "name": "sourceId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "scriptwriters_sourceId_unique": {
+          "name": "scriptwriters_sourceId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "sourceId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.showtimes": {
+      "name": "showtimes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cityId": {
+          "name": "cityId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "showtimes_cityId_cities_id_fk": {
+          "name": "showtimes_cityId_cities_id_fk",
+          "tableFrom": "showtimes",
+          "tableTo": "cities",
+          "columnsFrom": [
+            "cityId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "showtimes_url_unique": {
+          "name": "showtimes_url_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "url"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.socials_images": {
+      "name": "socials_images",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "data": {
+          "name": "data",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contentType": {
+          "name": "contentType",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.socials_posts": {
+      "name": "socials_posts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "postDate": {
+          "name": "postDate",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform": {
+          "name": "platform",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'instagram_post'"
+        },
+        "contentType": {
+          "name": "contentType",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'feed_candidate'"
+        },
+        "movieId": {
+          "name": "movieId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "screeningId": {
+          "name": "screeningId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "published": {
+          "name": "published",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "socials_posts_movieId_movies_id_fk": {
+          "name": "socials_posts_movieId_movies_id_fk",
+          "tableFrom": "socials_posts",
+          "tableTo": "movies",
+          "columnsFrom": [
+            "movieId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "socials_posts_screeningId_screenings_id_fk": {
+          "name": "socials_posts_screeningId_screenings_id_fk",
+          "tableFrom": "socials_posts",
+          "tableTo": "screenings",
+          "columnsFrom": [
+            "screeningId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "socials_posts_postDate_platform_content_type_unique": {
+          "name": "socials_posts_postDate_platform_content_type_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "postDate",
+            "platform",
+            "contentType"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/src/database/migrations/meta/_journal.json
+++ b/src/database/migrations/meta/_journal.json
@@ -50,6 +50,13 @@
       "when": 1781275548835,
       "tag": "0006_abnormal_crusher_hogan",
       "breakpoints": true
+    },
+    {
+      "idx": 7,
+      "version": "7",
+      "when": 1781546158955,
+      "tag": "0007_smooth_marvel_zombies",
+      "breakpoints": true
     }
   ]
 }

--- a/src/database/schemas/cinemas.schema.ts
+++ b/src/database/schemas/cinemas.schema.ts
@@ -22,6 +22,8 @@ export const cinemasTable = pgTable('cinemas', {
   latitude: real(),
   street: varchar({ length: 255 }),
   description: text(),
+  email: varchar({ length: 255 }),
+  website: varchar({ length: 255 }),
   createdAt: timestamp().notNull().defaultNow(),
   updatedAt: timestamp().notNull().defaultNow(),
 });

--- a/src/scripts/import-cinema-contacts.ts
+++ b/src/scripts/import-cinema-contacts.ts
@@ -1,0 +1,107 @@
+/**
+ * Import / refresh of cinema contact data (`email`, `website`).
+ *
+ * Reads a semicolon-separated CSV with the columns
+ *   filmweb;miasto;kino;email;website;rodzaj;zrodlo
+ * and matches each row to a cinema by its Filmweb URL (`cinemas.url`, the same
+ * URL the scraper stores). For every match it sets `email` and/or `website`
+ * when the CSV provides a non-empty, non-"NOT_FOUND" value; existing values are
+ * kept when the CSV cell is empty, so the script is idempotent and safe to
+ * re-run. `updatedAt` is intentionally NOT touched - it tracks content changes
+ * consumed by the sitemap/IndexNow flow, not contact-data edits.
+ *
+ * The CSV lives outside this repo (cinema contacts contain personal data), so
+ * its path must be passed explicitly.
+ *
+ * Usage:
+ *   bunx ts-node -r dotenv/config src/scripts/import-cinema-contacts.ts \
+ *     --csv ../outreach/kina-maile-IMPORT.csv [--dry-run]
+ */
+import 'dotenv/config';
+import { readFileSync } from 'node:fs';
+import { Client } from 'pg';
+
+interface ContactRow {
+  filmweb: string;
+  email: string | null;
+  website: string | null;
+}
+
+const argValue = (name: string): string | undefined => {
+  const i = process.argv.indexOf(name);
+  return i !== -1 ? process.argv[i + 1] : undefined;
+};
+
+/** Parses the import CSV into rows that carry a usable email and/or website. */
+const parseCsv = (path: string): ContactRow[] => {
+  const lines = readFileSync(path, 'utf8')
+    .split(/\r?\n/)
+    .filter((l) => l.trim().length > 0);
+
+  const rows: ContactRow[] = [];
+  for (const line of lines.slice(1)) {
+    const cols = line.split(';');
+    const filmweb = (cols[0] ?? '').trim();
+    const rawEmail = (cols[3] ?? '').trim();
+    const rawWebsite = (cols[4] ?? '').trim();
+    if (!filmweb) continue;
+
+    const email = rawEmail && rawEmail !== 'NOT_FOUND' ? rawEmail : null;
+    const website = rawWebsite.length > 0 ? rawWebsite : null;
+    if (!email && !website) continue;
+
+    rows.push({ filmweb, email, website });
+  }
+  return rows;
+};
+
+const run = async (dryRun: boolean, csvPath: string) => {
+  const rows = parseCsv(csvPath);
+  const client = new Client(process.env.DATABASE_URL);
+  await client.connect();
+
+  try {
+    let updated = 0;
+    const unmatched: string[] = [];
+
+    await client.query('BEGIN');
+    for (const row of rows) {
+      const res = await client.query(
+        `UPDATE cinemas
+            SET email = COALESCE($1, email),
+                website = COALESCE($2, website)
+          WHERE url = $3`,
+        [row.email, row.website, row.filmweb],
+      );
+      if (res.rowCount && res.rowCount > 0) {
+        updated += res.rowCount;
+      } else {
+        unmatched.push(row.filmweb);
+      }
+    }
+    await client.query(dryRun ? 'ROLLBACK' : 'COMMIT');
+
+    console.log(
+      `${dryRun ? '[dry-run] would update' : 'Updated'} ${updated} of ` +
+        `${rows.length} cinemas (${unmatched.length} CSV rows had no matching cinemas.url).`,
+    );
+    if (unmatched.length > 0) {
+      console.log(`Unmatched Filmweb URLs:\n  ${unmatched.join('\n  ')}`);
+    }
+  } finally {
+    await client.end();
+  }
+};
+
+const csvPath = argValue('--csv');
+if (!csvPath) {
+  console.error(
+    'Usage: import-cinema-contacts.ts --csv <path-to-csv> [--dry-run]',
+  );
+  process.exit(1);
+}
+
+run(process.argv.includes('--dry-run'), csvPath).catch((err) => {
+  console.error('Import failed:', err);
+  process.exit(1);
+});


### PR DESCRIPTION
## What

- Add nullable `email` and `website` columns to the `cinemas` table (migration `0007_smooth_marvel_zombies`).
- Add `src/scripts/import-cinema-contacts.ts` (npm script `db:import-cinema-contacts`) that backfills both columns from a semicolon-separated CSV, matching each row to a cinema by its Filmweb URL (`cinemas.url`).

## Why

`cinemas.url` stores the Filmweb URL, not the cinema's own website. We gathered verified contact e-mails and official websites for the cinemas Klaps lists, and need them in the database for outreach and for linking out to each cinema's site.

## Notes

- The import script is idempotent (`COALESCE` keeps existing values), supports `--dry-run`, and intentionally does **not** touch `updatedAt` (that column tracks content changes consumed by the sitemap/IndexNow flow).
- The contacts CSV lives outside the repo because it contains personal data; its path is passed via `--csv`.
- Updated the cinemas service spec mock to include the new columns. `lint`, `build`, `tsc --noEmit` and `test` all pass.

## How to apply

```
bun run db:migrate
bun run db:import-cinema-contacts --csv <path-to-csv> --dry-run
bun run db:import-cinema-contacts --csv <path-to-csv>
```
