### PR TITLE
feat(search): match original title in movie and repertoire search

### DIFF
--- a/src/movies/movies.repository.ts
+++ b/src/movies/movies.repository.ts
@@ -10,7 +10,7 @@ import type {
   DirectorInsertDto,
 } from './dto/create-movies-batch.dto';
 import type { UpdateMovieDto } from './dto/update-movie.dto';
-import { and, desc, eq, gte, ilike, inArray, sql } from 'drizzle-orm';
+import { and, desc, eq, gte, ilike, inArray, or, sql } from 'drizzle-orm';
 import { directorSlug, movieSlug, toSlug, uniqueSlug } from '../lib/slug';
 import { excludedChanged } from '../lib/upsert';
 import { sortAndChunk } from '../lib/chunked-upsert';
@@ -44,9 +44,7 @@ export class MoviesRepository {
     offset?: number;
   }) {
     const where = and(
-      params?.search
-        ? ilike(schema.movies.title, `%${params.search}%`)
-        : undefined,
+      this.buildSearchCondition(params?.search),
       this.buildGenreCondition(params?.genreId),
       this.buildDirectorCondition(params?.directorId),
     );
@@ -66,9 +64,7 @@ export class MoviesRepository {
     directorId?: number;
   }) {
     const where = and(
-      params?.search
-        ? ilike(schema.movies.title, `%${params.search}%`)
-        : undefined,
+      this.buildSearchCondition(params?.search),
       this.buildGenreCondition(params?.genreId),
       this.buildDirectorCondition(params?.directorId),
     );
@@ -321,6 +317,16 @@ export class MoviesRepository {
       .select({ slug: schema.movies.slug })
       .from(schema.movies);
     return new Set(rows.map((r) => r.slug));
+  }
+
+  private buildSearchCondition(search?: string) {
+    if (!search) return undefined;
+    // Match both the Polish title and the original title, so e.g. "fight"
+    // surfaces "Podziemny krąg" (Fight Club).
+    return or(
+      ilike(schema.movies.title, `%${search}%`),
+      ilike(schema.movies.titleOriginal, `%${search}%`),
+    );
   }
 
   private buildGenreCondition(genreId?: number) {

--- a/src/screenings/screenings.repository.spec.ts
+++ b/src/screenings/screenings.repository.spec.ts
@@ -279,6 +279,23 @@ describe('ScreeningsRepository', () => {
       // Director subquery is built via the plain select() builder.
       expect(mockSelect).toHaveBeenCalled();
     });
+
+    it('should build a movies subquery when search provided', async () => {
+      selectDistinctChain = createChain([{ movieId: 42 }]);
+      mockSelectDistinct.mockReturnValue(selectDistinctChain);
+
+      const result = await repo.findFilteredMovieIds({
+        ...baseParams,
+        search: 'fight',
+      });
+
+      expect(result).toEqual([42]);
+      // Search filter matches title OR titleOriginal via a movies subquery:
+      // select → from → where.
+      expect(mockSelect).toHaveBeenCalled();
+      expect(selectChain.from).toHaveBeenCalled();
+      expect(selectChain.where).toHaveBeenCalled();
+    });
   });
 
   describe('findMoviesWithScreenings', () => {

--- a/src/screenings/screenings.repository.ts
+++ b/src/screenings/screenings.repository.ts
@@ -13,6 +13,7 @@ import {
   lte,
   max,
   ne,
+  or,
 } from 'drizzle-orm';
 import type { CreateScreeningDto } from './dto/create-screening.dto';
 import type { Screening } from './screenings.types';
@@ -331,12 +332,19 @@ export class ScreeningsRepository {
 
   private buildSearchFilter(search?: string) {
     if (!search) return undefined;
+    // Match both the Polish title and the original title, so e.g. "fight"
+    // surfaces "Podziemny krąg" (Fight Club).
     return inArray(
       schema.screenings.movieId,
       this.db
         .select({ id: schema.movies.id })
         .from(schema.movies)
-        .where(ilike(schema.movies.title, `%${search}%`)),
+        .where(
+          or(
+            ilike(schema.movies.title, `%${search}%`),
+            ilike(schema.movies.titleOriginal, `%${search}%`),
+          ),
+        ),
     );
   }
 


### PR DESCRIPTION
## Problem

The repertoire search on the homepage (`/screenings?search=`) and the movie catalog (`/movies?search=`) filtered **only** by the Polish `movies.title`. A query like "fight" returned nothing, even though Fight Club is in the database as `title: "Podziemny krąg"` with `titleOriginal: "Fight Club"` and has upcoming screenings. Searching "podziemny" or "krąg" worked; the original title was never matched.

## Fix

Both search filters now match the Polish title **OR** the original title via `or(ilike(title), ilike(titleOriginal))`:

- `screenings.repository.ts` → `buildSearchFilter`
- `movies.repository.ts` → new `buildSearchCondition` helper, used by both `findAll` and `count` (removes the duplicated inline condition)

## Tests

Added a test covering the previously untested `search` path in `ScreeningsRepository`.

`lint`, `build`, `test` (300/300) and `tsc --noEmit` all pass.